### PR TITLE
Fix subtitle centering issue

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,6 +53,11 @@ h2 {
     font-style: italic; /* Elegant style for subheadings */
 }
 
+/* Subtitle */
+.subtitle {
+    text-align: center; /* Center the subtitle text */
+}
+
 /* Paragraphs */
 p {
     margin: 20px 0;


### PR DESCRIPTION
Fixes #1

Add CSS rule to center the subtitle text.

* Add a new CSS rule for the `subtitle` class in `styles.css`
* Use `text-align: center;` to center the subtitle text

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nkzarrabi/ethical-exploration-caving/pull/2?shareId=7cd5f572-5e2e-48ad-9721-1282a73dd1be).